### PR TITLE
Updating nuntius version and establishing connection on boot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'bson_ext'
 gem 'bunny'
 
 gem 'mumukit-core', '~> 1.1'
-gem 'mumukit-nuntius', '~> 5.0'
+gem 'mumukit-nuntius', '~> 6.0'
 
 gem 'mumukit-auth', '~> 7.0'
 gem 'mumukit-service', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       omniauth-auth0 (~> 1.1)
       omniauth-saml (~> 1.6)
       rack (>= 1.5)
-    mumukit-nuntius (5.0.0)
+    mumukit-nuntius (6.0.0)
       bunny (~> 2.3)
       mumukit-core (~> 1.0)
     mumukit-platform (0.11.0)
@@ -187,7 +187,7 @@ DEPENDENCIES
   mumukit-core (~> 1.1)
   mumukit-inspection (~> 1.0)
   mumukit-login (~> 4.0)
-  mumukit-nuntius (~> 5.0)
+  mumukit-nuntius (~> 6.0)
   mumukit-platform (~> 0.11)
   mumukit-service (~> 3.0)
   pry

--- a/lib/classroom.rb
+++ b/lib/classroom.rb
@@ -30,6 +30,8 @@ Mumukit::Nuntius.configure do |c|
   c.notification_mode = Mumukit::Nuntius::NotificationMode.from_env
 end
 
+Mumukit::Nuntius.establish_connection
+
 Mumukit::Auth.configure do |_config|
 
 end


### PR DESCRIPTION
Classroom api uses puma in single mode.
When puma starts in single mode, `on_worker_boot` doesn't get executed because the Master Process isn't a Worker.