### PR TITLE
Remove duplicated routes - Finishes #136

### DIFF
--- a/app/routes/courses.rb
+++ b/app/routes/courses.rb
@@ -38,10 +38,6 @@ Mumukit::Platform.map_organization_routes!(self) do
     allowed_courses permissions
   end
 
-  get '/api/courses' do
-    allowed_courses permissions
-  end
-
   post '/courses' do
     current_user.protect! :janitor, json_body[:slug]
     course = Course.create! with_organization(json_body)
@@ -61,11 +57,6 @@ Mumukit::Platform.map_organization_routes!(self) do
   end
 
   get '/courses/:course/guides' do
-    authorize! :teacher
-    {guides: Guide.where(with_organization_and_course).as_json}
-  end
-
-  get '/api/courses/:course/guides' do
     authorize! :teacher
     {guides: Guide.where(with_organization_and_course).as_json}
   end

--- a/app/routes/exams.rb
+++ b/app/routes/exams.rb
@@ -14,19 +14,7 @@ Mumukit::Platform.map_organization_routes!(self) do
     {exams: Exam.where(with_organization_and_course).as_json}
   end
 
-  get '/api/courses/:course/exams' do
-    authorize! :teacher
-    {exams: Exam.where(with_organization_and_course).as_json}
-  end
-
   post '/courses/:course/exams' do
-    authorize! :teacher
-    exam = Exam.create! with_organization_and_course(json_body)
-    exam.notify!
-    {status: :created}.merge(eid: exam.eid)
-  end
-
-  post '/api/courses/:course/exams' do
     authorize! :teacher
     exam = Exam.create! with_organization_and_course(json_body)
     exam.notify!
@@ -41,7 +29,7 @@ Mumukit::Platform.map_organization_routes!(self) do
     {status: :updated}.merge(eid: exam_id)
   end
 
-  post '/api/courses/:course/exams/:exam_id/students/:uid' do
+  post '/courses/:course/exams/:exam_id/students/:uid' do
     authorize! :teacher
     exam = Exam.find_by!(exam_query)
     exam.add_student! params[:uid]

--- a/app/routes/messages.rb
+++ b/app/routes/messages.rb
@@ -43,7 +43,7 @@ Mumukit::Platform.map_organization_routes!(self) do
     render_threads(course_slug)
   end
 
-  get '/api/guides/:organization/:repository/:exercise_id/student/:uid/messages' do
+  get '/guides/:organization/:repository/:exercise_id/student/:uid/messages' do
     render_threads Student.last_updated_student_by(with_organization uid: uid).course
   end
 end

--- a/app/routes/students.rb
+++ b/app/routes/students.rb
@@ -1,6 +1,6 @@
 helpers do
-  def students_query
-    with_detached_and_search with_organization_and_course
+  def students_query(query_params = {})
+    with_detached_and_search with_organization_and_course.merge(query_params)
   end
 
   def normalize_student!
@@ -14,19 +14,13 @@ Mumukit::Platform.map_organization_routes!(self) do
 
   get '/courses/:course/students' do
     authorize! :teacher
-    count, students = Sorting.aggregate(Student, students_query, paginated_params)
+    query_params = params.slice('uid', 'personal_id')
+    count, students = Sorting.aggregate(Student, students_query(query_params), paginated_params)
     {
       page: page + 1,
       total: count,
       students: students
     }
-  end
-
-  get '/api/courses/:course/students' do
-    # // TODO: Unificar con la de arriba
-    authorize! :teacher
-    query_params = params.slice('uid', 'personal_id')
-    {students: Student.where(with_organization_and_course.merge query_params)}
   end
 
   get '/courses/:course/students/:uid' do

--- a/app/routes/students.rb
+++ b/app/routes/students.rb
@@ -23,12 +23,13 @@ Mumukit::Platform.map_organization_routes!(self) do
   end
 
   get '/api/courses/:course/students' do
+    # // TODO: Unificar con la de arriba
     authorize! :teacher
     query_params = params.slice('uid', 'personal_id')
     {students: Student.where(with_organization_and_course.merge query_params)}
   end
 
-  get '/api/courses/:course/students/:uid' do
+  get '/courses/:course/students/:uid' do
     authorize! :teacher
     {guide_students_progress: GuideProgress.where(with_organization_and_course 'student.uid': uid).sort(created_at: :asc).as_json}
   end

--- a/spec/exams_spec.rb
+++ b/spec/exams_spec.rb
@@ -33,21 +33,6 @@ describe Exam do
     it { expect(exam_fetched.as_json).to json_like(exam_json.merge(organization: 'example.org', course: 'example.org/foo'), except_fields) }
   end
 
-  describe 'post /api/courses/:course/exams' do
-    let(:exam_json) { {slug: 'foo/bar', start_time: 'tomorrow', end_time: 'tomorrow', duration: 150, language: 'haskell', name: 'foo', uids: []}.as_json }
-    let(:exam_fetched) { Exam.find_by organization: 'example.org', course: 'example.org/foo' }
-
-    before { expect(Mumukit::Nuntius).to receive(:notify_event!).with('UpsertExam', exam_json.merge('organization' => 'example.org', 'eid' => kind_of(String))) }
-    before { header 'Authorization', build_mumuki_auth_header('*') }
-    before { post '/api/courses/foo/exams', exam_json.to_json }
-
-    it { expect(last_response.body).to be_truthy }
-    it { expect(last_response.body).to json_like({status: 'created'}, except_fields) }
-    it { expect(Exam.count).to eq 1 }
-    it { expect(exam_fetched.eid).to be_truthy }
-    it { expect(exam_fetched.as_json).to json_like exam_json.merge(organization: 'example.org', course: 'example.org/foo'), except_fields }
-  end
-
   describe 'get /courses/:course/exams/:exam_id' do
     let(:exam_id) { Exam.create!(exam_json.merge organization: 'example.org', course: 'example.org/foo').eid }
     let(:exam_json) { {slug: 'foo/bar', start_time: 'tomorrow', end_time: 'tomorrow', duration: 150, language: 'haskell', name: 'foo', uids: []} }
@@ -79,7 +64,7 @@ describe Exam do
 
   end
 
-  describe 'post /api/courses/:course/exams/:exam/students/:uid' do
+  describe 'post /courses/:course/exams/:exam/students/:uid' do
     let(:exam_id) { Exam.create!(exam_json.merge organization: 'example.org', course: 'example.org/foo').eid }
     let(:exam_json) { {slug: 'foo/bar', start_time: 'tomorrow', end_time: 'tomorrow', duration: 150, language: 'haskell', name: 'foo', uids: ['auth0|234567', 'auth0|345678']}.stringify_keys }
     let(:exam_fetched) { Exam.last }
@@ -87,7 +72,7 @@ describe Exam do
     context 'when existing exam' do
       before { expect(Mumukit::Nuntius).to receive(:notify_event!).exactly(1).times }
       before { header 'Authorization', build_mumuki_auth_header('*') }
-      before { post "/api/courses/foo/exams/#{exam_id}/students/agus@mumuki.org" }
+      before { post "/courses/foo/exams/#{exam_id}/students/agus@mumuki.org" }
 
       it { expect(last_response.body).to be_truthy }
       it { expect(last_response.body).to json_like({status: 'updated'}, except_fields) }

--- a/spec/guides_progress_spec.rb
+++ b/spec/guides_progress_spec.rb
@@ -47,12 +47,12 @@ describe Course do
 
   end
 
-  describe 'get /api/courses/:course/students/:uid' do
+  describe 'get /courses/:course/students/:uid' do
 
     before { header 'Authorization', build_mumuki_auth_header('*') }
 
     context 'when guide_progress exist' do
-      before { get '/api/courses/k2048/students/agus@mumuki.org' }
+      before { get '/courses/k2048/students/agus@mumuki.org' }
 
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_like({guide_students_progress: [with_course(guide_progress1),

--- a/spec/guides_spec.rb
+++ b/spec/guides_spec.rb
@@ -37,7 +37,7 @@ describe Guide do
 
     context 'when no guides in a course yet' do
       before { header 'Authorization', build_mumuki_auth_header('*') }
-      before { get '/api/courses/foo/guides' }
+      before { get '/courses/foo/guides' }
 
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq guides: [] }
@@ -49,7 +49,7 @@ describe Guide do
       before { Guide.create! guide3.merge(organization: 'example.org', course: 'example.org/bar') }
 
       before { header 'Authorization', build_mumuki_auth_header('*') }
-      before { get '/api/courses/foo/guides' }
+      before { get '/courses/foo/guides' }
 
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_like({guides: [with_course(guide1), with_course(guide2)]}, except_fields) }

--- a/spec/students_spec.rb
+++ b/spec/students_spec.rb
@@ -126,7 +126,7 @@ describe Student do
       let(:student_saved) { {organization: 'example.org', course: 'example.org/foo'}.merge student }
       let(:student_saved2) { {organization: 'example.org', course: 'example.org/foo'}.merge student2 }
 
-      context 'when guides already exists in a course' do
+      context 'when guides already exists in a course'  do
         before { Student.create! student.merge(organization: 'example.org', course: 'example.org/foo') }
         before { Student.create! student.merge(organization: 'example.org', course: 'example.org/test') }
         before { Student.create! student2.merge(organization: 'example.org', course: 'example.org/foo') }
@@ -141,7 +141,7 @@ describe Student do
         end
         context 'get students with auth client' do
           before { header 'Authorization', build_mumuki_auth_header('*') }
-          before { get '/api/courses/foo/students?personal_id=2&uid=bazlol@gmail.com' }
+          before { get '/courses/foo/students?personal_id=2&uid=bazlol@gmail.com' }
 
           it { expect(last_response).to be_ok }
           it { expect(last_response.body).to json_like({students: [student_saved2]}, except_fields) }


### PR DESCRIPTION
Finishes #136 

I removed all the duplicated endpoints prefixed with `/api` and unified the two students endpoints.

:warning: The `/courses/:course/students` endpoints was adding `:detached=>{:$exists=>false}` to the query and the `/api/courses/:course/students` wasn't. I'm assuming this was a bug, and we always want to add the `detached` filter.