### PR TITLE
Add chilean translations

### DIFF
--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -1,0 +1,3 @@
+---
+es-CL:
+  view_solution: Ver solución


### PR DESCRIPTION
Requires https://github.com/mumuki/mumukit-platform/pull/38.
Requires https://github.com/mumuki/mumuki-classroom-api/pull/153.

Really this change is only to add es-CL to `I18n`'s available_locales