### PR TITLE
Restricting invitations for janitor only

### DIFF
--- a/app/routes/courses.rb
+++ b/app/routes/courses.rb
@@ -100,7 +100,7 @@ Mumukit::Platform.map_organization_routes!(self) do
   end
 
   post '/courses/:course/invitation' do
-    authorize! :teacher
+    authorize! :janitor
     course = Course.find_by! with_organization slug: course_slug
     {invitation: course.invitation_link!(json_body[:expiration_date])}
   end


### PR DESCRIPTION
This only forbids teacher from creating invitation links but they will still be able to obtain them via api once created