### PR TITLE
Update icons to FontAwesome5

### DIFF
--- a/lib/mumuki/views/threads.html.erb
+++ b/lib/mumuki/views/threads.html.erb
@@ -4,7 +4,7 @@
         <div class="thread">
           <li class="solution self">
             <a onclick="toggleCollapse('toggle-<%= index %>')">
-              <i class="fa fa-<%= threads.last == thread ? 'minus' : 'plus' %>-square-o toggle-<%= index %>"></i>
+              <i class="far fa-<%= threads.last == thread ? 'minus' : 'plus' %>-square toggle-<%= index %>"></i>
               <span>&nbsp;</span>
               <span> <%= I18n.t(:view_solution) %> </span>
             </a>
@@ -32,8 +32,8 @@
   function toggleCollapse(target) {
     var $target = $('#' + target);
     var $icon = $('i.' + target);
-    $icon.toggleClass('fa-minus-square-o');
-    $icon.toggleClass('fa-plus-square-o');
+    $icon.toggleClass('fa-minus-square');
+    $icon.toggleClass('fa-plus-square');
     $target.toggleClass('hidden');
   }
 


### PR DESCRIPTION
## :dart: Goal

Use FontAwesome5 syntax for icons.

## :spiral_notepad: Notes

The biggest change on FA5 is that instead of having solid and outlined icons with different `fa-` prefixes (such as `fa-user` and `fa-user-o`), the style is now dictated by `fas` (s for solid), `far` (r for regular) and `fab` (b for brand). Therefore, `fas fa-user` shows a solid user icon, `far fa-user` shows the outlined style, and `fab fa-twitter` is the style for brand icons.
