### PR TITLE
Add all teachers endpoint

### DIFF
--- a/lib/mumuki/classroom/sinatra/teachers.rb
+++ b/lib/mumuki/classroom/sinatra/teachers.rb
@@ -1,8 +1,18 @@
 class Mumuki::Classroom::App < Sinatra::Application
   Mumukit::Platform.map_organization_routes!(self) do
+    helpers do
+      def list_teachers(matcher)
+        authorize! :headmaster
+        {teachers: Mumuki::Classroom::Teacher.where(matcher).as_json}
+      end
+    end
+
+    get '/teachers' do
+      list_teachers with_organization
+    end
+
     get '/courses/:course/teachers' do
-      authorize! :headmaster
-      {teachers: Mumuki::Classroom::Teacher.where(with_organization_and_course).as_json}
+      list_teachers with_organization_and_course
     end
 
     post '/courses/:course/teachers' do

--- a/spec/teachers_spec.rb
+++ b/spec/teachers_spec.rb
@@ -3,8 +3,44 @@ require 'spec_helper'
 describe Mumuki::Classroom::Teacher, workspaces: [:organization] do
 
   let(:except_fields) { {except: [:created_at, :updated_at]} }
-
   let(:response) { struct JSON.parse(last_response.body) }
+
+  describe 'get /teachers' do
+    let(:john) do
+      {
+        email: 'john@gmail.com',
+        first_name: 'John',
+        last_name: 'John',
+        uid: 'auth0|1',
+        organization: 'example.org',
+        course: 'example.org/2020-K2020'
+      }
+    end
+
+    let(:mary) do
+      {
+        email: 'mary@gmail.com',
+        first_name: 'Mary',
+        last_name: 'Mary',
+        uid: 'auth0|1',
+        organization: 'example.org',
+        course: 'example.org/2021-K2020'
+      }
+    end
+    before { header 'Authorization', build_auth_header('*') }
+
+    context 'when there are teachers at multiple courses' do
+      before do
+        Mumuki::Classroom::Teacher.create! john
+        Mumuki::Classroom::Teacher.create! mary
+      end
+      before { get '/teachers' }
+
+      it { expect(last_response).to be_ok }
+      it { expect(last_response.body).to json_like({teachers: [john, mary]}, except_fields) }
+    end
+
+  end
 
   describe 'get /courses/:course/teachers' do
 


### PR DESCRIPTION
# :dart: Goal 

To add a `/teachers` endpoints, that generalizes the teachers-per-course list. 

# :back: Backwards compatibility

100% backwards compatible