### PR TITLE
Fix sort memory limit exceeded error

### DIFF
--- a/lib/mumuki/classroom/models/reporting.rb
+++ b/lib/mumuki/classroom/models/reporting.rb
@@ -17,8 +17,8 @@ module Reporting
     main_pipeline << {'$match': query}
     main_pipeline.concat searching.pipeline
     main_pipeline.concat sorting.pipeline
-    main_pipeline << {'$project': projection}
     main_pipeline << {'$sort': sorting.order_by(ordering)}
+    main_pipeline << {'$project': projection}
   end
 
 end

--- a/lib/mumuki/classroom/models/sorting.rb
+++ b/lib/mumuki/classroom/models/sorting.rb
@@ -2,7 +2,7 @@ module Sorting
 
   def self.aggregate(collection, query, paginated_params, query_params)
     reporting_pipeline = Reporting.build_pipeline(collection, query, paginated_params, query_params, projection)
-    query = collection.collection.aggregate(pipeline paginated_params, reporting_pipeline).first
+    query = collection.collection.aggregate(pipeline(paginated_params, reporting_pipeline), allow_disk_use: true).first # Must allow disk use for sorting large collections by non-index
     query_results(query)
   end
 


### PR DESCRIPTION
Using project stage before sort stage prevents mongo from accessing collection through index, so moving that earlier in the pipeline as suggested by @luchotc:
https://docs.mongodb.com/manual/reference/operator/aggregation/sort/#sort-operator-and-performance

This fixes the error when sorting through indexed fields, but not for progress, which is not indexed.

According to mongo docs, aggregation pipeline stages have a non-configurable 100MB memory limit: https://docs.mongodb.com/manual/core/aggregation-pipeline-limits/#memory-restrictions

so it seems the only possible solution was to allow disk use for the aggregation.