### PR TITLE
Add email, first and last name validations

### DIFF
--- a/lib/mumuki/classroom/event/user_changed.rb
+++ b/lib/mumuki/classroom/event/user_changed.rb
@@ -29,8 +29,11 @@ class Mumuki::Classroom::Event::UserChanged
       if students.exists?
         students.first.attach!
       else
-        student = Mumuki::Classroom::Student.attributes_from_uid uid
-        Mumuki::Classroom::Student.create! student.merge(organization: organization, course: granted_slug.to_s)
+        student = Mumuki::Classroom::Student.new(
+          Mumuki::Classroom::Student
+            .attributes_from_uid(uid)
+            .merge(organization: organization, course: granted_slug.to_s))
+        student.save! validate: false
       end
     end
 
@@ -41,8 +44,9 @@ class Mumuki::Classroom::Event::UserChanged
 
     def teacher_added(organization, user, granted_slug)
       uid = user[:uid]
-      teacher = Mumuki::Classroom::Teacher.find_or_create_by!(organization: organization, course: granted_slug.to_s, uid: uid)
-      teacher.update_attributes!(Mumuki::Classroom::Teacher.attributes_from_uid(uid))
+      teacher = Mumuki::Classroom::Teacher.find_or_initialize_by(organization: organization, course: granted_slug.to_s, uid: uid)
+      teacher.assign_attributes(Mumuki::Classroom::Teacher.attributes_from_uid(uid))
+      teacher.save! validate: false
     end
 
     def teacher_removed(organization, user, granted_slug)

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -243,7 +243,12 @@ HTML
         json = JSON.parse(error_message.message)
         response.body = json.to_json
       rescue
-        response.body = {message: error_message.message}.to_json
+        if error_message.is_a?(Mongoid::Errors::MongoidError)
+          message_text = error_message.summary
+        else
+          message_text = error_message.message
+        end
+        response.body = {message: message_text}.to_json
       end
     end
   end

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -256,6 +256,10 @@ HTML
     halt 400
   end
 
+  error Mongoid::Errors::Validations do
+    halt 400
+  end
+
   error ActiveRecord::RecordNotFound do
     halt 404
   end

--- a/lib/mumuki/classroom/sinatra/massive.rb
+++ b/lib/mumuki/classroom/sinatra/massive.rb
@@ -170,7 +170,7 @@ class Mumuki::Classroom::App < Sinatra::Application
       Mumuki::Classroom::Student.send "#{method}_all_by!", students_uids, with_organization_and_course
       User.where(uid: students_uids).each do |user|
         user.send "#{action}_permission!", :student, course_slug
-        user.save!
+        user.save! validate: false
       end
     end
 

--- a/lib/mumuki/classroom/sinatra/massive.rb
+++ b/lib/mumuki/classroom/sinatra/massive.rb
@@ -170,7 +170,7 @@ class Mumuki::Classroom::App < Sinatra::Application
       Mumuki::Classroom::Student.send "#{method}_all_by!", students_uids, with_organization_and_course
       User.where(uid: students_uids).each do |user|
         user.send "#{action}_permission!", :student, course_slug
-        user.save! validate: false
+        user.save!
       end
     end
 

--- a/lib/mumuki/classroom/sinatra/massive.rb
+++ b/lib/mumuki/classroom/sinatra/massive.rb
@@ -37,13 +37,13 @@ class Mumuki::Classroom::App < Sinatra::Application
 
       post '/students/detach' do
         update_students! do |processed|
-          update_students_at_course! :detach, :remove, processed
+          update_students_permissions_at_course! :detach, :remove, processed
         end
       end
 
       post '/students/attach' do
         update_students! do |processed|
-          update_students_at_course! :attach, :add, processed
+          update_students_permissions_at_course! :attach, :add, processed
         end
       end
 
@@ -166,7 +166,7 @@ class Mumuki::Classroom::App < Sinatra::Application
                        students_does_not_belong_msg, status: :updated
     end
 
-    def update_students_at_course!(method, action, students_uids)
+    def update_students_permissions_at_course!(method, action, students_uids)
       Mumuki::Classroom::Student.send "#{method}_all_by!", students_uids, with_organization_and_course
       User.where(uid: students_uids).each do |user|
         user.send "#{action}_permission!", :student, course_slug

--- a/lib/mumuki/classroom/sinatra/massive.rb
+++ b/lib/mumuki/classroom/sinatra/massive.rb
@@ -98,7 +98,7 @@ class Mumuki::Classroom::App < Sinatra::Application
       user = User.find_or_initialize_by(uid: member[:uid])
       user.assign_attributes user_from_member_json(member)
       user.add_permission! role, course_slug
-      user.verify_name!
+      user.verify_name! force: true
       yield user if block_given?
     end
 

--- a/lib/mumuki/classroom/sinatra/students.rb
+++ b/lib/mumuki/classroom/sinatra/students.rb
@@ -1,11 +1,5 @@
 class Mumuki::Classroom::App < Sinatra::Application
   helpers do
-    def normalize_student!
-      json_body[:email] = json_body[:email]&.downcase
-      json_body[:last_name] = json_body[:last_name]&.downcase&.titleize
-      json_body[:first_name] = json_body[:first_name]&.downcase&.titleize
-    end
-
     def list_students(matcher)
       authorize! :teacher
       count, students = Sorting.aggregate(Mumuki::Classroom::Student, with_detached_and_search(matcher, Mumuki::Classroom::Student), paginated_params, query_params)

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -197,14 +197,14 @@ TEST
     end
 
     context 'when fields aren\'t complete' do
-      let(:student) { full_student.except(:first_name, :personal_id) }
+      let(:student) { full_student.except(:personal_id) }
       it do
         expect(last_response.body).to eq <<TEST
 last_name,first_name,email,personal_id,detached,created_at,last_submission_date,passed_count,passed_with_warnings_count,failed_count,last_lesson_type,last_lesson_name,last_exercise_number,last_exercise_name,last_chapter
-Bar,,baz@bar.com,1212,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,120,2,27,Exam,Exam Test,1,Test,Test Chapter
+Bar,Foo,baz@bar.com,1212,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,120,2,27,Exam,Exam Test,1,Test,Test Chapter
 Bar,Bar,bar@foo.com,2222,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,120,1,27,Exam,Exam Test,1,Test,Test Chapter
-Bar,,foo@bar.com,,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,117,1,27,Exam,Exam Test,1,Test,Test Chapter
-Bar,,bar@baz.com,9191,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,100,2,27,Exam,Exam Test,1,Test,Test Chapter
+Bar,Foo,foo@bar.com,,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,117,1,27,Exam,Exam Test,1,Test,Test Chapter
+Bar,Foo,bar@baz.com,9191,false,2016-08-01T18:39:57.000Z,2016-08-01T18:39:57.481Z,100,2,27,Exam,Exam Test,1,Test,Test Chapter
 TEST
       end
     end

--- a/spec/exams_spec.rb
+++ b/spec/exams_spec.rb
@@ -6,8 +6,8 @@ describe Exam, workspaces: [:organization, :courses] do
   let(:course) { Course.locate! 'example.org/foo' }
   let(:language) { Language.for_name 'haskell' }
   let(:guide) { create :guide, slug: 'foo/bar', name: 'foo', language: language }
-  let(:jane) { create :user, uid: 'jane.doe@testing.com' }
-  let(:john) { create :user, uid: 'john.doe@testing.com' }
+  let(:jane) { create :user, uid: 'jane.doe@testing.com', email: 'jane.doe@testing.com' }
+  let(:john) { create :user, uid: 'john.doe@testing.com', email: 'john.doe@testing.com' }
 
   let(:start_time) { 1.month.ago.beginning_of_day }
   let(:end_time) { 1.month.since.beginning_of_day }

--- a/spec/factories/student_factory.rb
+++ b/spec/factories/student_factory.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :student, class: Mumuki::Classroom::Student do
     organization { Organization.current.name }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
   end
 end

--- a/spec/massive_spec.rb
+++ b/spec/massive_spec.rb
@@ -28,24 +28,28 @@ describe 'Massive API', workspaces: [:organization, :courses] do
 
   def create_students_in(course, uids, student = {})
     uids.each do |it|
-      User.new(uid: it).tap { |u| u.add_permission! :student, course.slug }.save!
+      user = create(:user, uid: it, permissions: {student: course.slug})
       Mumuki::Classroom::Student.create!({
         organization: course.organization.name,
         course: course.slug,
         uid: it,
-        first_name: Faker::Name.first_name,
-        last_name: Faker::Name.last_name,
-        email: Faker::Internet.email
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email: user.email
       }.merge(student))
     end
   end
 
   def create_teachers_in(course, uids)
     uids.each do |it|
-      User.new(uid: it).tap { |u| u.add_permission! :teacher, course.slug }.save!
+      user = create(:user, uid: it, permissions: {teacher: course.slug})
       Mumuki::Classroom::Teacher.create!(
-        {organization: course.organization.name, course: course.slug, uid: it}
-      )
+        organization: course.organization.name,
+        course: course.slug,
+        uid: it,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email: user.email)
     end
   end
 
@@ -129,8 +133,8 @@ describe 'Massive API', workspaces: [:organization, :courses] do
   let(:end_time) { 1.month.since.beginning_of_day }
 
   shared_examples 'with verified names for users' do
-    it { expect(modified_users.all? { |us| us.verified_first_name == us.first_name }).to be true }
-    it { expect(modified_users.all? { |us| us.verified_last_name == us.last_name }).to be true }
+    it { expect(modified_users.map(&:verified_last_name)).to eq modified_users.map(&:last_name) }
+    it { expect(modified_users.map(&:verified_first_name)).to eq modified_users.map(&:first_name) }
   end
 
   describe 'when authenticated' do

--- a/spec/massive_spec.rb
+++ b/spec/massive_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Massive API', workspaces: [:organization, :courses] do
 
   def to_member_request_hash(number)
-    {first_name: "first_name_#{number}", last_name: "last_name_#{number}", email: "email_#{number}@fake.com"}
+    {first_name: "http_first_name_#{number}", last_name: "http_last_name#{number}", email: "http_email_#{number}@fake.com"}
   end
 
   def to_guide_progress(guide, uid, stats, eid, status)
@@ -28,8 +28,9 @@ describe 'Massive API', workspaces: [:organization, :courses] do
 
   def create_students_in(course, uids, student = {})
     uids.each do |it|
-      user = create(:user, uid: it, permissions: {student: course.slug})
-      Mumuki::Classroom::Student.create!({
+      user = build(:user, uid: it, permissions: {student: course.slug})
+      user.verify_name!
+      create(:student, {
         organization: course.organization.name,
         course: course.slug,
         uid: it,
@@ -42,7 +43,8 @@ describe 'Massive API', workspaces: [:organization, :courses] do
 
   def create_teachers_in(course, uids)
     uids.each do |it|
-      user = create(:user, uid: it, permissions: {teacher: course.slug})
+      user = build(:user, uid: it, permissions: {teacher: course.slug})
+      user.verify_name!
       Mumuki::Classroom::Teacher.create!(
         organization: course.organization.name,
         course: course.slug,

--- a/spec/massive_spec.rb
+++ b/spec/massive_spec.rb
@@ -425,12 +425,7 @@ describe 'Massive API', workspaces: [:organization, :courses] do
         before { Exam.upsert_students! eid: classroom_id, added: [jane.uid, john.uid] }
         before do
           uids.take(students_count).each do |it|
-            Mumuki::Classroom::Student.create! uid: it,
-                                               first_name: Faker::Name.first_name,
-                                               last_name: Faker::Name.last_name,
-                                               email: Faker::Internet.email,
-                                               organization: organization.name,
-                                               course: course.slug
+            create :student, uid: it, organization: organization.name, course: course.slug
           end
         end
         before { post "/api/courses/foo/massive/exams/#{classroom_id}/students", exam_uids.to_json }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,12 @@ Mumukit::Auth.configure do |c|
 end
 
 def build_auth_header(permissions, sub = 'github|123456')
-  user = User.where(uid: sub).first_or_create! permissions: Mumukit::Auth::Permissions.parse(owner: permissions)
+  user = User
+          .where(uid: sub)
+          .first_or_create! first_name: Faker::Name.first_name,
+                            last_name: Faker::Name.last_name,
+                            email: Faker::Internet.email,
+                            permissions: Mumukit::Auth::Permissions.parse(owner: permissions)
   Mumukit::Auth::Token.encode user.uid, {}
 end
 

--- a/spec/students_spec.rb
+++ b/spec/students_spec.rb
@@ -223,7 +223,7 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
       before { put '/courses/foo/students/jondoe@gmail.com', {last_name: 'Doe'}.to_json }
 
       it { expect(last_response).to_not be_ok }
-      it { expect(last_response.body['message']).to include("First name can't be blank, Email can't be blank") }
+      it { expect(last_response.body).to json_eq(message: "The following errors were found: First name can't be blank, Email can't be blank, Email is invalid") }
       it { expect(Mumuki::Classroom::Student.find_by(uid: 'jondoe@gmail.com').last_name).to eq 'Din' }
       it { expect(updated_user.first_name).to eq 'Jon' }
       it { expect(updated_user.last_name).to eq 'Din' }

--- a/spec/students_spec.rb
+++ b/spec/students_spec.rb
@@ -7,8 +7,8 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
 
   let(:except_fields) { {except: [:created_at, :updated_at, :page, :total]} }
 
-  let(:student1) { {uid: 'github|123456', first_name: 'Dorothy'} }
-  let(:student2) { {uid: 'twitter|123456', first_name: 'John'} }
+  let(:student1) { {uid: 'github|123456', first_name: 'Dorothy', last_name: 'Doe', email: 'dorodoe@mail.com'} }
+  let(:student2) { {uid: 'twitter|123456', first_name: 'John', last_name: 'Doe', email: 'jdoe@mail.com'} }
 
   let(:guide1) { {slug: 'foo/bar'} }
   let(:guide2) { {slug: 'bar/baz'} }
@@ -205,7 +205,7 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
   describe 'put /courses/:course/students/:student_id' do
     let(:updated_user) { User.locate! 'jondoe@gmail.com' }
 
-    before { User.create! first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', permissions: {student: 'example.org/*'} }
+    before { create :user, first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', permissions: {student: 'example.org/*'} }
     before { Mumuki::Classroom::Student.create! first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', image_url: 'http://foo', organization: 'example.org', course: 'example.org/foo' }
     before { header 'Authorization', build_auth_header('*') }
     before { put '/courses/foo/students/jondoe@gmail.com', {last_name: 'Doe'}.to_json }
@@ -220,11 +220,11 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
   describe 'when needs mumuki-user' do
     let(:fetched_student) { Mumuki::Classroom::Student.find_by(uid: 'github|123456') }
     let(:user) { User.locate! 'github|123456' }
-    let(:janitor) { User.create uid: 'janitor@mumuki.org', permissions: { janitor: '*/*' } }
+    let(:janitor) { create :user, uid: 'janitor@mumuki.org', permissions: { janitor: '*/*' } }
 
     describe 'post /courses/:course/students/:student_id/detach' do
 
-      before { User.create! example_students.call(student1).as_user }
+      before { create :user, example_students.call(student1).as_user }
 
       context 'should be detached' do
         before { header 'Authorization', build_auth_header('example.org/*', janitor.uid) }

--- a/spec/students_spec.rb
+++ b/spec/students_spec.rb
@@ -89,8 +89,8 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
     describe '#report' do
       let(:report) { Mumuki::Classroom::Student.report({organization: 'example.org', course: 'example.org/example'}) }
       it { expect(report.count).to eq 2 }
-      it { expect(report.first).to json_like({first_name: 'Dorothy'}, except_fields) }
-      it { expect(report.second).to json_like({first_name: 'John'}, except_fields) }
+      it { expect(report.first).to json_like({first_name: 'Dorothy', email: "dorodoe@mail.com", last_name: "Doe"}, except_fields) }
+      it { expect(report.second).to json_like({first_name: 'John', email: "jdoe@mail.com", last_name: "Doe"}, except_fields) }
     end
 
     context 'if no students stats processed' do
@@ -233,7 +233,7 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
   describe 'when needs mumuki-user' do
     let(:fetched_student) { Mumuki::Classroom::Student.find_by(uid: 'github|123456') }
     let(:user) { User.locate! 'github|123456' }
-    let(:janitor) { create :user, uid: 'janitor@mumuki.org', permissions: { janitor: '*/*' } }
+    let(:janitor) { create :user, uid: 'janitor@mumuki.org', email: 'janitor@mumuki.org', permissions: { janitor: '*/*' } }
 
     describe 'post /courses/:course/students/:student_id/detach' do
 

--- a/spec/students_spec.rb
+++ b/spec/students_spec.rb
@@ -58,7 +58,7 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
   let(:example_students) {
     -> (student) {
       new_student = student.merge(organization: 'example.org', course: 'example.org/example')
-      Mumuki::Classroom::Student.create! new_student
+      create :student, new_student
     }
   }
 
@@ -138,10 +138,10 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
                         email: 'a.teacher@gmail.com', uids: [student[:uid]]} }
 
       context 'when guides already exists in a course' do
-        before { Mumuki::Classroom::Student.create! student.merge(organization: 'example.org', course: 'example.org/foo') }
-        before { Mumuki::Classroom::Student.create! student.merge(organization: 'example.org', course: 'example.org/test') }
-        before { Mumuki::Classroom::Student.create! student2.merge(organization: 'example.org', course: 'example.org/foo') }
-        before { Mumuki::Classroom::Student.create! student2.merge(organization: 'example.org', course: 'example.org/test') }
+        before { create :student, student.merge(organization: 'example.org', course: 'example.org/foo') }
+        before { create :student, student.merge(organization: 'example.org', course: 'example.org/test') }
+        before { create :student, student2.merge(organization: 'example.org', course: 'example.org/foo') }
+        before { create :student, student2.merge(organization: 'example.org', course: 'example.org/test') }
         before { Mumuki::Classroom::Follower.create! follower }
 
         context 'get students with auth0 client' do
@@ -182,7 +182,7 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
     let(:student) { {first_name: 'Jon', last_name: 'Doe', email: 'jondoe@gmail.com', image_url: 'http://foo'} }
     let(:json) { {student: student.merge(uid: 'auth0|1'), course: {slug: 'example.org/foo'}} }
     let(:created_at) { 'created_at' }
-    before { Mumuki::Classroom::Student.create!(student.merge(uid: 'auth0|1', organization: 'example.org', course: 'example.org/foo')) }
+    before { create :student, student.merge(uid: 'auth0|1', organization: 'example.org', course: 'example.org/foo') }
     before { get '/courses/foo/student/auth0%7c1' }
 
     it { expect(last_response).to be_ok }
@@ -198,15 +198,15 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
 
     it { expect(last_response).to be_ok }
     it { expect(last_response.body).to json_eq status: :created }
-    it { expect(created_user.first_name).to eq created_user.verified_first_name }
-    it { expect(created_user.last_name).to eq created_user.verified_last_name }
+    it { expect(created_user.first_name).to_not be nil }
+    it { expect(created_user.last_name).to_not be nil }
   end
 
   describe 'put /courses/:course/students/:student_id' do
     let(:updated_user) { User.locate! 'jondoe@gmail.com' }
 
     before { create :user, first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', permissions: {student: 'example.org/*'} }
-    before { Mumuki::Classroom::Student.create! first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', image_url: 'http://foo', organization: 'example.org', course: 'example.org/foo' }
+    before { create :student, first_name: 'Jon', last_name: 'Din', email: 'jondoe@gmail.com', uid: 'jondoe@gmail.com', image_url: 'http://foo', organization: 'example.org', course: 'example.org/foo' }
     before { header 'Authorization', build_auth_header('*') }
 
     context "when passing complete data" do
@@ -504,10 +504,10 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
         }
       end
 
-      before { Mumuki::Classroom::Student.create! student1 }
-      before { Mumuki::Classroom::Student.create! student2 }
-      before { Mumuki::Classroom::Student.create! student3 }
-      before { Mumuki::Classroom::Student.create! student4 }
+      before { create :student, student1 }
+      before { create :student, student2 }
+      before { create :student, student3 }
+      before { create :student, student4 }
 
       before { header 'Authorization', build_auth_header('*') }
 
@@ -581,10 +581,10 @@ describe Mumuki::Classroom::Student, workspaces: [:organization, :courses] do
         passed_with_warnings: 1
       }
     } }
-    before { Mumuki::Classroom::Student.create! student }
-    before { Mumuki::Classroom::Student.create! student.merge uid: 'bar@baz.com', email: 'bar@baz.com', personal_id: '9191', stats: {failed: 27, passed: 100, passed_with_warnings: 2} }
-    before { Mumuki::Classroom::Student.create! student.merge uid: 'baz@bar.com', email: 'baz@bar.com', personal_id: '1212', stats: {failed: 27, passed: 120, passed_with_warnings: 2}, course: 'example.org/bar' }
-    before { Mumuki::Classroom::Student.create! student.merge first_name: 'Bar', uid: 'bar@foo.com', email: 'bar@foo.com', personal_id: '2222', stats: {failed: 27, passed: 120, passed_with_warnings: 1}, course: 'example.org/bar' }
+    before { create :student, student }
+    before { create :student, student.merge(uid: 'bar@baz.com', email: 'bar@baz.com', personal_id: '9191', stats: {failed: 27, passed: 100, passed_with_warnings: 2}) }
+    before { create :student, student.merge(uid: 'baz@bar.com', email: 'baz@bar.com', personal_id: '1212', stats: {failed: 27, passed: 120, passed_with_warnings: 2}, course: 'example.org/bar') }
+    before { create :student, student.merge(first_name: 'Bar', uid: 'bar@foo.com', email: 'bar@foo.com', personal_id: '2222', stats: {failed: 27, passed: 120, passed_with_warnings: 1}, course: 'example.org/bar') }
     before { header 'Authorization', build_auth_header('*') }
     before { get '/students/report' }
     it do


### PR DESCRIPTION
## :dart: Goal

To prevent members with missing names or invalid email to be entered through classroom. 

## :memo: Details

A big part of this PR is just test-fixing and test-refactoring. However a few new tests have been added and the following logic has been altered: 

* `student` and `teacher` objects are not been validated when entered through the `UserChanged` interface
*  Presence of `uid first_name last_name email` and correctness of `email` is always validated by default
* Mongoid validation errors are treated specially on the REST interface
* names verification is forced when names are entered from this app.  See https://github.com/mumuki/mumuki-domain/commit/6efecd698bf811f2fb8dcf1420fece6b1bfe8d15. Prior of this, new names were ignored. This bug was detected while refactoring and fixing tests


## :eyes: See also

Depends on https://github.com/mumuki/mumuki-domain/pull/259