### PR TITLE
Chore normalize slugs

### DIFF
--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -102,13 +102,6 @@ class Mumuki::Classroom::App < Sinatra::Application
       json_body.merge(tenant: tenant)
     end
 
-    def ensure_normalized_slug!(slug)
-      slug = slug.to_mumukit_slug
-      if !slug.normalize.eql? slug
-        raise Mumukit::Auth::InvalidSlugFormatError, 'Only normalized slugs should be used to create a course'
-      end
-    end
-
     def ensure_course_existence!
       Course.locate! course_slug
     end

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -50,9 +50,9 @@ class Mumuki::Classroom::App < Sinatra::Application
 
     def slug
       if route_slug_parts.present?
-        Mumukit::Auth::Slug.join(*route_slug_parts)
+        Mumukit::Auth::Slug.join(*route_slug_parts).normalize
       elsif json_body
-        Mumukit::Auth::Slug.parse(json_body['slug'])
+        json_body['slug'].to_mumukit_slug.normalize
       else
         raise Mumukit::Auth::InvalidSlugFormatError.new('Slug not available')
       end
@@ -91,11 +91,11 @@ class Mumuki::Classroom::App < Sinatra::Application
     end
 
     def course_slug
-      @course_slug ||= Mumukit::Auth::Slug.join_s(*route_slug_parts)
+      @course_slug ||= Mumukit::Auth::Slug.join(*route_slug_parts).normalize.to_s
     end
 
     def repo_slug
-      @repo_slug ||= Mumukit::Auth::Slug.join_s(params[:organization], params[:repository])
+      @repo_slug ||= Mumukit::Auth::Slug.join(params[:organization], params[:repository]).normalize.to_s
     end
 
     def tenantized_json_body

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -102,6 +102,13 @@ class Mumuki::Classroom::App < Sinatra::Application
       json_body.merge(tenant: tenant)
     end
 
+    def ensure_normalized_slug!(slug)
+      slug = slug.to_mumukit_slug
+      if !slug.normalize.eql? slug
+        raise Mumukit::Auth::InvalidSlugFormatError, 'Only normalized slugs should be used to create a course'
+      end
+    end
+
     def ensure_course_existence!
       Course.locate! course_slug
     end

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -98,6 +98,7 @@ class Mumuki::Classroom::App < Sinatra::Application
       authorize! :janitor
       ensure_organization_existence!
       Course.create! with_current_organization(json_body)
+                      .merge(slug: json_body[:slug].to_mumukit_slug.normalize.to_s)
       {status: :created}
     end
 

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -97,7 +97,6 @@ class Mumuki::Classroom::App < Sinatra::Application
     post '/courses' do
       authorize! :janitor
       ensure_organization_existence!
-      ensure_normalized_slug! json_body[:slug]
       Course.create! with_current_organization(json_body)
       {status: :created}
     end

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -97,6 +97,7 @@ class Mumuki::Classroom::App < Sinatra::Application
     post '/courses' do
       authorize! :janitor
       ensure_organization_existence!
+      ensure_normalized_slug! json_body[:slug]
       Course.create! with_current_organization(json_body)
       {status: :created}
     end

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -95,7 +95,7 @@ class Mumuki::Classroom::App < Sinatra::Application
     end
 
     post '/courses' do
-      current_user.protect! :janitor, json_body[:slug]
+      authorize! :janitor
       ensure_organization_existence!
       Course.create! with_current_organization(json_body)
       {status: :created}

--- a/lib/mumuki/classroom/sinatra/students.rb
+++ b/lib/mumuki/classroom/sinatra/students.rb
@@ -64,7 +64,7 @@ class Mumuki::Classroom::App < Sinatra::Application
     post '/courses/:course/students/:uid/transfer' do
       authorize! :admin
 
-      destination = Mumukit::Auth::Slug.join organization, json_body[:destination]
+      destination = Mumukit::Auth::Slug.join(organization, json_body[:destination]).normalize
 
       Mumuki::Classroom::Student.find_by!(with_organization_and_course uid: uid).transfer_to!  organization, destination.to_s
 

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,7 +26,7 @@ describe Course do
   end
 
   describe 'post /courses' do
-    let(:slug) { 'example.org/2016-k2001' }
+    let(:slug) { 'example.org/2016-K2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
@@ -54,7 +54,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-k2001' }
+      it { expect(created_slug).to eq 'example.org/2016-K2001' }
     end
 
     context 'when is global admin' do
@@ -64,7 +64,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-k2001' }
+      it { expect(created_slug).to eq 'example.org/2016-K2001' }
     end
 
     context 'when slug is ill-formed' do
@@ -82,9 +82,10 @@ describe Course do
       before { header 'Authorization', build_auth_header('*') }
       before { post '/courses', new_course.to_json }
 
-      it { expect(last_response).to_not be_ok }
-      it { expect(last_response.body).to json_eq message: 'Only normalized slugs should be used to create a course' }
-      it { expect(Course.count).to eq 0 }
+      it { expect(last_response).to be_ok }
+      it { expect(last_response.body).to json_eq status: 'created' }
+      it { expect(Course.count).to eq 1 }
+      it { expect(created_slug).to eq 'example.org/2021-2Q' }
     end
 
     context 'when course already exists' do

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,7 +26,7 @@ describe Course do
   end
 
   describe 'post /courses' do
-    let(:slug) { 'example.org/2016-K2001' }
+    let(:slug) { 'example.org/2016-k2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
@@ -54,7 +54,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when is global admin' do
@@ -64,7 +64,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when slug is ill-formed' do
@@ -85,7 +85,21 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2021-2Q' }
+      it { expect(created_slug).to eq 'example.org/2021-2q' }
+
+      context 'when it is fetched by its unnormalized, uppercase form' do
+        before { get '/courses/2021-2Q'  }
+
+        it { expect(last_response).to be_ok }
+        it { expect(last_response.status).to eq 200 }
+      end
+
+      context 'when it is fetched by its unnormalized, urlencoded form' do
+        before { get '/courses/2021%202Q'  }
+
+        it { expect(last_response).to be_ok }
+        it { expect(last_response.status).to eq 200 }
+      end
     end
 
     context 'when course already exists' do

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,7 +26,7 @@ describe Course do
   end
 
   describe 'post /courses' do
-    let(:slug) { 'example.org/2016-K2001' }
+    let(:slug) { 'example.org/2016-k2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
@@ -54,7 +54,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when is global admin' do
@@ -64,7 +64,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when slug is ill-formed' do
@@ -82,10 +82,9 @@ describe Course do
       before { header 'Authorization', build_auth_header('*') }
       before { post '/courses', new_course.to_json }
 
-      it { expect(last_response).to be_ok }
-      it { expect(last_response.body).to json_eq status: 'created' }
-      it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2021-2Q' }
+      it { expect(last_response).to_not be_ok }
+      it { expect(last_response.body).to json_eq message: 'Only normalized slugs should be used to create a course' }
+      it { expect(Course.count).to eq 0 }
     end
 
     context 'when course already exists' do

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,13 +26,14 @@ describe Course do
   end
 
   describe 'post /courses' do
+    let(:slug) { 'example.org/2016-K2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
                     shifts: ['morning'],
                     description: 'haskell',
                     organization: 'example.org',
-                    slug: 'example.org/2016-K2001'} }
+                    slug: slug} }
     let(:new_course_slug) { new_course[:slug] }
     let(:created_slug) { Course.last.slug }
 
@@ -64,6 +65,27 @@ describe Course do
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
       it { expect(created_slug).to eq 'example.org/2016-K2001' }
+    end
+
+    context 'when slug is ill-formed' do
+      let(:slug) { 'example.org-2021-2Q' }
+      before { header 'Authorization', build_auth_header('*') }
+      before { post '/courses', new_course.to_json }
+
+      it { expect(last_response).to_not be_ok }
+      it { expect(last_response.body).to json_eq message: 'Invalid slug: example.org-2021-2Q. It must be in first/second format' }
+      it { expect(Course.count).to eq 0 }
+    end
+
+    context 'when slug is not normalized' do
+      let(:slug) { 'example.org/2021 2Q' }
+      before { header 'Authorization', build_auth_header('*') }
+      before { post '/courses', new_course.to_json }
+
+      it { expect(last_response).to be_ok }
+      it { expect(last_response.body).to json_eq status: 'created' }
+      it { expect(Course.count).to eq 1 }
+      it { expect(created_slug).to eq 'example.org/2021-2Q' }
     end
 
     context 'when course already exists' do


### PR DESCRIPTION
# :dart: Goal

To prevent courses with unnormalized to be created. 

# :memo: Details

This PRs also makes usage of normalized and non-normalized slugs transparent. 

# :back: Backwards compatibility

This PR is not backwards compatible, since previously persisted unnormalized slugs will not be accessible anymore.  