### PR TITLE
Chore validate slug normalization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,5 @@ group :development do
 end
 
 
-gem 'mumukit-auth', github: 'mumuki/mumukit-auth', branch: 'cc73f15069b90b28fa6db5ef694d7414e292fc2f'
+gem 'mumukit-auth', github: 'mumuki/mumukit-auth', branch: 'feature-improved-normalization-methods'
 gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-permissions-compact'

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'web-console'
 end
+
+
+gem 'mumukit-auth', github: 'mumuki/mumukit-auth', branch: 'cc73f15069b90b28fa6db5ef694d7414e292fc2f'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-permissions-compact'

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -104,7 +104,7 @@ class Mumuki::Classroom::App < Sinatra::Application
 
     def ensure_normalized_slug!(slug)
       slug = slug.to_mumukit_slug
-      if !slug.normalize.eql? slug
+      unless slug.normalized?
         raise Mumukit::Auth::InvalidSlugFormatError, 'Only normalized slugs should be used to create a course'
       end
     end

--- a/lib/mumuki/classroom/sinatra.rb
+++ b/lib/mumuki/classroom/sinatra.rb
@@ -102,6 +102,13 @@ class Mumuki::Classroom::App < Sinatra::Application
       json_body.merge(tenant: tenant)
     end
 
+    def ensure_normalized_slug!(slug)
+      slug = slug.to_mumukit_slug
+      if !slug.normalize.eql? slug
+        raise Mumukit::Auth::InvalidSlugFormatError, 'Only normalized slugs should be used to create a course'
+      end
+    end
+
     def ensure_course_existence!
       Course.locate! course_slug
     end

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -97,6 +97,7 @@ class Mumuki::Classroom::App < Sinatra::Application
     post '/courses' do
       authorize! :janitor
       ensure_organization_existence!
+      ensure_normalized_slug! json_body[:slug]
       Course.create! with_current_organization(json_body)
       {status: :created}
     end

--- a/lib/mumuki/classroom/sinatra/courses.rb
+++ b/lib/mumuki/classroom/sinatra/courses.rb
@@ -95,7 +95,7 @@ class Mumuki::Classroom::App < Sinatra::Application
     end
 
     post '/courses' do
-      current_user.protect! :janitor, json_body[:slug]
+      authorize! :janitor
       ensure_organization_existence!
       Course.create! with_current_organization(json_body)
       {status: :created}

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,7 +26,7 @@ describe Course do
   end
 
   describe 'post /courses' do
-    let(:slug) { 'example.org/2016-K2001' }
+    let(:slug) { 'example.org/2016-k2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
@@ -54,7 +54,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when is global admin' do
@@ -64,7 +64,7 @@ describe Course do
       it { expect(last_response).to be_ok }
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2016-K2001' }
+      it { expect(created_slug).to eq 'example.org/2016-k2001' }
     end
 
     context 'when slug is ill-formed' do
@@ -82,10 +82,9 @@ describe Course do
       before { header 'Authorization', build_auth_header('*') }
       before { post '/courses', new_course.to_json }
 
-      it { expect(last_response).to be_ok }
-      it { expect(last_response.body).to json_eq status: 'created' }
-      it { expect(Course.count).to eq 1 }
-      it { expect(created_slug).to eq 'example.org/2021-2Q' }
+      it { expect(last_response).to_not be_ok }
+      it { expect(last_response.body).to json_eq message: 'Only normalized slugs should be used to create a course' }
+      it { expect(Course.count).to eq 0 }
     end
 
     context 'when course already exists' do

--- a/spec/courses_spec.rb
+++ b/spec/courses_spec.rb
@@ -26,13 +26,14 @@ describe Course do
   end
 
   describe 'post /courses' do
+    let(:slug) { 'example.org/2016-K2001' }
     let(:new_course) { {code: 'K2001',
                     days: %w(monday saturday),
                     period: '2016',
                     shifts: ['morning'],
                     description: 'haskell',
                     organization: 'example.org',
-                    slug: 'example.org/2016-K2001'} }
+                    slug: slug} }
     let(:new_course_slug) { new_course[:slug] }
     let(:created_slug) { Course.last.slug }
 
@@ -64,6 +65,27 @@ describe Course do
       it { expect(last_response.body).to json_eq status: 'created' }
       it { expect(Course.count).to eq 1 }
       it { expect(created_slug).to eq 'example.org/2016-K2001' }
+    end
+
+    context 'when slug is ill-formed' do
+      let(:slug) { 'example.org-2021-2Q' }
+      before { header 'Authorization', build_auth_header('*') }
+      before { post '/courses', new_course.to_json }
+
+      it { expect(last_response).to_not be_ok }
+      it { expect(last_response.body).to json_eq message: 'Invalid slug: example.org-2021-2Q. It must be in first/second format' }
+      it { expect(Course.count).to eq 0 }
+    end
+
+    context 'when slug is not normalized' do
+      let(:slug) { 'example.org/2021 2Q' }
+      before { header 'Authorization', build_auth_header('*') }
+      before { post '/courses', new_course.to_json }
+
+      it { expect(last_response).to be_ok }
+      it { expect(last_response.body).to json_eq status: 'created' }
+      it { expect(Course.count).to eq 1 }
+      it { expect(created_slug).to eq 'example.org/2021-2Q' }
     end
 
     context 'when course already exists' do


### PR DESCRIPTION
# :dart: Goal

To prevent unnormalized slugs to be created

# :memo: Details

My original intention was to normalize slugs in a transparent way, just like bibliotheca does. However, that would lead to potential backwards incompatibility issue - #245 . Thus, I am only validating normalization but not fixing it. 

# :warning: Dependencies

* Rebase after #247
 

# :back: Backwards compatibility

This PR is 100% backwards compatible. 