### PR TITLE
Feature Permissions compact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'web-console'
 end
+
+
+gem 'mumukit-auth', github: 'mumuki/mumukit-auth', branch: 'cc73f15069b90b28fa6db5ef694d7414e292fc2f'
+gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'feature-permissions-compact'


### PR DESCRIPTION
## :dart: Goal

To compact permissions across multiple roles.

## :memo: Details

This PR fis only an update to the mumukit-auth gem. It fixes a few tests that incorrectly added student and teachers permissions to the same user and course, as if they were different courses. 

## :warning: Dependencies

* https://github.com/mumuki/mumukit-auth/pull/46
* https://github.com/mumuki/mumuki-domain/pull/264

## :back: Backwards compatibility

100% backwards compatible

